### PR TITLE
modify BOOTEASY.ASM to compile on current version of NASM

### DIFF
--- a/SOURCE/BOOTEASY/BOOTEASY.ASM
+++ b/SOURCE/BOOTEASY/BOOTEASY.ASM
@@ -74,7 +74,7 @@ Boot:
 Load:
 		mov	DX,BP		; restore drive number
 		pop	AX		; key '1'..'5'
-		mov     [Base+default],AL	; save function key number
+		mov     [Base+defaultLocal],AL	; save function key number
 		cmp	AL,'5'
 		je	SwitchDrive
 		mov	AH,16
@@ -200,7 +200,7 @@ waitkey:
 		cmp     DX,BX           ; check for timeout
 		jb      waitkey		; wait for scancode
 loaddefault:
-		mov     AL,[Base+default]	; prior system id
+		mov     AL,[Base+defaultLocal]	; prior system id
 		jmp     short testkey		; boot default system
 reply:
 		int     16h             ; AH=0, keybd bios service
@@ -247,7 +247,7 @@ SaveBoot:
 		xor     DH,DH		; drive #, head 0
 		int     13h		; replace boot record
 		pop	SI
-		mov     byte [Base+default],'?' ; reset default
+		mov     byte [Base+defaultLocal],'?' ; reset defaultLocal
 		ret
 
 ; -------------------------------
@@ -257,7 +257,7 @@ FkeyMsg         db      13,10,'F'
 key             db      '0 . . .',' '+80h,'disk '
 diskNum		db	'1'
 defaultMsg	db	13,10,10,'Default: F'
-default         db      '?',' '+80h
+defaultLocal    db      '?',' '+80h
 
 nameTable       db      fat     -namtab,   1
                 db      fat     -namtab,   4
@@ -308,4 +308,4 @@ noname		db	'?','?'+80h
 		dw	0aa55h		; magic
 
 ;code		ends
-		end
+;		end


### PR DESCRIPTION
BOOTEASY.ASM would compile on NASM 0.98.15, but won't compile on more current 2.1x.x versions.

On NASM version 2.13.02 here are the errors when given `nasm -f obj BOOTEASY.ASM`:
```
BOOTEASY.ASM:260: error: invalid parameter to [default] directive
BOOTEASY.ASM:311: warning: label alone on a line without a colon might be in error [-w+orphan-labels]
```

The error on 260 this error is due to [DEFAULT now being a directive in NASM](https://www.nasm.us/xdoc/2.15.05/html/nasmdoc7.html#section-7.2).  I simply changed `default` to `defaultLocal`.

On line 311 is because of the `end`.  I guess it was expecting a label.  Perhaps `end` may have been some kind of keyword at some point.  I dunno, I try to stay away from assembly if at all possible.

Fixing those two errors fixes the errors and the code assembles on NASM 2.1x.x.

I assembled the current code and then the changed code with NASM 0.98.15 and got the exact same .OBJ files.

I've used the program dhex under Linux to compare these binaries. 

TOP is the original assembled with 0.98.15.  BOTTOM is assembled with NASM 2.15.05 under DOS.  The yellow hexadecimal and text are the changes.  The version number is the only change.
![Screenshot from 2021-01-11 20-50-35](https://user-images.githubusercontent.com/7433104/104263209-bb361c80-544e-11eb-8504-979b6ed79976.png)

TOP is the original assembled with 0.98.15.  BOTTOM is assembled with NASM 2.13.02 under Linux.   The yellow hexadecimal and text are the changes.  The version number and the filename being capitalized are the only changes.
![Screenshot from 2021-01-11 20-56-08](https://user-images.githubusercontent.com/7433104/104263584-7ced2d00-544f-11eb-8f02-5fdacd13f63a.png)

