### PR TITLE
Source differences from version 1.3.1 Beta

### DIFF
--- a/SOURCE/FDISK/CMD.C
+++ b/SOURCE/FDISK/CMD.C
@@ -5,8 +5,8 @@
 //                      All functions that process command line entry are
 //                      here.
 // Written By:  Brian E. Reifsnyder
-// Version:  1.2.1
-// Copyright:  1998-2002 under the terms of the GNU GPL, Version 2
+// Version:  1.3.0
+// Copyright:  1998-2008 under the terms of the GNU GPL, Version 2
 */
 
 /*
@@ -162,7 +162,7 @@ void Command_Line_Create_Extended_Partition()
   maximum_partition_size_in_MB = Max_Pri_Part_Size_In_MB(EXTENDED);
 
   maximum_possible_percentage
-   = Convert_To_Percentage(maximum_partition_size_in_MB
+   = (int)Convert_To_Percentage(maximum_partition_size_in_MB
    ,pDrive->total_hard_disk_size_in_MB);
 
 //   ,pDrive->ext_part_size_in_MB);
@@ -216,7 +216,7 @@ void Command_Line_Create_Logical_DOS_Drive()
   maximum_partition_size_in_MB = Max_Log_Part_Size_In_MB();
 
   maximum_possible_percentage
-   = Convert_To_Percentage(maximum_partition_size_in_MB
+   = (int)Convert_To_Percentage(maximum_partition_size_in_MB
    ,pDrive->ext_part_size_in_MB);
 
   if(arg[0].extra_value==100)
@@ -281,7 +281,7 @@ void Command_Line_Create_Primary_Partition()
   maximum_partition_size_in_MB = Max_Pri_Part_Size_In_MB(PRIMARY);
 
   maximum_possible_percentage
-   = Convert_To_Percentage(maximum_partition_size_in_MB
+   = (int)Convert_To_Percentage(maximum_partition_size_in_MB
    ,pDrive->total_hard_disk_size_in_MB);
 
 

--- a/SOURCE/FDISK/FDISKIO.C
+++ b/SOURCE/FDISK/FDISKIO.C
@@ -6,8 +6,8 @@
 //                      Functions that access the hard disk and are specific
 //                      to Free FDISK are in this module.
 // Written By:  Brian E. Reifsnyder
-// Version:  1.2.1
-// Copyright:  1998-2002 under the terms of the GNU GPL, Version 2
+// Version:  1.3.1
+// Copyright:  1998-2008 under the terms of the GNU GPL, Version 2
 */
 
 /*
@@ -94,7 +94,7 @@ void Automatically_Partition_Hard_Drive()
   Determine_Free_Space();
   if( pDrive->pri_part_largest_free_space > 0)
     {
-    Create_Primary_Partition(5,999999);
+    Create_Primary_Partition(5,999999L);
 
     /* Fill the extended partition with logical drives. */
     Determine_Free_Space();

--- a/SOURCE/FDISK/HELPSCR.C
+++ b/SOURCE/FDISK/HELPSCR.C
@@ -3,8 +3,8 @@
 // Written By:  Brian E. Reifsnyder
 // Module:  HELPSCR.C
 // Module Description:  User Interface Code Module
-// Version:  1.2.1
-// Copyright:  1998-2002 under the terms of the GNU GPL, Version 2
+// Version:  1.3.1
+// Copyright:  1998-2008 under the terms of the GNU GPL, Version 2
 */
 
 /*

--- a/SOURCE/FDISK/KBDINPUT.C
+++ b/SOURCE/FDISK/KBDINPUT.C
@@ -3,8 +3,8 @@
 // Written By:  Brian E. Reifsnyder
 // Module:  KBDINPUT.C
 // Module Description:  Keyboard Interface Routine
-// Version:  1.2.1
-// Copyright:  1998-2002 under the terms of the GNU GPL, Version 2
+// Version:  1.3.1
+// Copyright:  1998-2008 under the terms of the GNU GPL, Version 2
 */
 
 /*

--- a/SOURCE/FDISK/MAIN.C
+++ b/SOURCE/FDISK/MAIN.C
@@ -3,8 +3,8 @@
 // Written By:  Brian E. Reifsnyder
 // Module:  MAIN.C
 // Module Description:  Main Free FDISK Code Module and Misc. Functions
-// Version:  1.2.1
-// Copyright:  1998-2002 under the terms of the GNU GPL, Version 2
+// Version:  1.3.1
+// Copyright:  1998-2008 under the terms of the GNU GPL, Version 2
 */
 
 
@@ -72,14 +72,14 @@ unsigned long computed_partition_size;
 
 unsigned long Convert_Cyl_To_MB(unsigned long num_cyl,unsigned long total_heads, unsigned long total_sect)
 {
-  unsigned long sect_per_meg = 1048576/512;
+  unsigned long sect_per_meg = 1048576UL/512UL;
   return( ( ( (num_cyl * total_heads) * total_sect)
 	    + (sect_per_meg/2)) / sect_per_meg );
 }
 
 unsigned long Convert_Sect_To_MB(unsigned long num_sect)
 {
-  unsigned long sect_per_meg = 1048576/512;
+  unsigned long sect_per_meg = 1048576UL/512UL;
 
   return((num_sect + (sect_per_meg/2)) / sect_per_meg);
 }

--- a/SOURCE/FDISK/MAIN.H
+++ b/SOURCE/FDISK/MAIN.H
@@ -4,7 +4,7 @@
 // Module Description:  Header File for MAIN.C
 // Written By:  Brian E. Reifsnyder
 // Version:  1.2.1
-// Copyright:  1998-2002 under the terms of the GNU GPL, Version 2
+// Copyright:  1998-2008 under the terms of the GNU GPL, Version 2
 */
 
 
@@ -23,15 +23,15 @@
 
 #define PRINAME "Free FDISK"
 #define ALTNAME "FreeDOS"
-#define VERSION "1.2.1"
-#define COPYLEFT "1998 - 2003"
+#define VERSION "1.3.1"
+#define COPYLEFT "1998 - 2008"
 
-//#define DEBUG
+#define DEBUG
 			 /* ***** Uncomment the above line to compile */
 			 /* ***** debugging code and functions into   */
 			 /* ***** Free FDISK.                         */
 
-//#define BETA_RELEASE
+#define BETA_RELEASE
 			 /* ***** Uncomment the above line to         */
 			 /* ***** have this program inform the user   */
 			 /* ***** that it is a beta release.          */

--- a/SOURCE/FDISK/PCOMPUTE.C
+++ b/SOURCE/FDISK/PCOMPUTE.C
@@ -3,8 +3,8 @@
 // Written By:  Brian E. Reifsnyder
 // Module:  PCOMPUTE.C
 // Module Description:  Partition Computation and Modification Functions
-// Version:  1.2.1
-// Copyright:  1998-2002 under the terms of the GNU GPL, Version 2
+// Version:  1.3.1
+// Copyright:  1998-2008 under the terms of the GNU GPL, Version 2
 */
 
 /*
@@ -1358,7 +1358,7 @@ unsigned long Number_Of_Cylinders(unsigned long size)
   unsigned long num_head;
   unsigned long size_in_mb = size/2048;
 
-  if (((size_in_mb * 1048576) % 512) != 0) size++;
+  if (((size_in_mb * 1048576UL) % 512UL) != 0) size++;
 
   num_head = size / pDrive->total_sect;
   if((size % pDrive->total_sect) != 0) num_head++;

--- a/SOURCE/FDISK/USERINT1.C
+++ b/SOURCE/FDISK/USERINT1.C
@@ -3,8 +3,8 @@
 // Written By:  Brian E. Reifsnyder
 // Module:  USERINT1.C
 // Module Description:  First User Interface Code Module
-// Version:  1.2.1
-// Copyright:  1998-2002 under the terms of the GNU GPL, Version 2
+// Version:  1.3.1
+// Copyright:  1998-2008 under the terms of the GNU GPL, Version 2
 */
 
 /*
@@ -201,7 +201,9 @@ void Interactive_User_Interface()
   if( (flags.version==W95B) || (flags.version==W98) )
    Ask_User_About_FAT32_Support();
 
-  Create_MBR_If_Not_Present();
+//  Create_MBR_If_Not_Present();     DO NOT AUTOMATICALLY CREATE THE MBR.
+//                                   THIS FEATURE WAS REQUESTED TO BE
+//                                   DISABLED.
 
   do
     {

--- a/SOURCE/FDISK/USERINT2.C
+++ b/SOURCE/FDISK/USERINT2.C
@@ -3,8 +3,8 @@
 // Written By:  Brian E. Reifsnyder
 // Module:  USERINT2.C
 // Module Description:  Second User Interface Code Module
-// Version:  1.2.1
-// Copyright:  1998-2003 under the terms of the GNU GPL, Version 2
+// Version:  1.3.1
+// Copyright:  1998-2008 under the terms of the GNU GPL, Version 2
 */
 
 /*
@@ -315,7 +315,7 @@ int Create_Logical_Drive_Interface()
       printf(" Mbytes ");
 
       maximum_possible_percentage
-       = Convert_To_Percentage(maximum_partition_size_in_MB
+       = (int)Convert_To_Percentage(maximum_partition_size_in_MB
        ,pDrive->ext_part_size_in_MB);
 
       cprintf("(%3d%%)",maximum_possible_percentage);


### PR DESCRIPTION
This PR contains the source differences from 1.2.1 to version 1.3.1 Beta.

There seems to be a few good changes that were made in the BETA version.  I'm not necessarily advocating for this to be merged.

(I anticipate that my next PR to be making sure that this compiles under Turbo C++ 3.0.   The PR after that I will replace some of the inline assembly code in order to make the code a little more portable for different compilers.) 

Here are some of the change in `NEWS.TXT`:
```
Current Version:
-----------------------------------------------------------------------------
Version 1.3.1   The MBR is no longer automatically written if the expected      
          
11/04/2008      MBR is not found.  The MBR is now only written by using
                the command line switches.

                Various warnings have been cleaned up in order to fix the 
                command-line compile.  One fix to the makefile remains.

                Error handling has been added in order to accomodate hard 
                disk and/or controller errors.

[...]

Version History:
-----------------------------------------------------------------------------
Version 1.3.0   Bug fixes provided by H. Peter Anvin in order to fix a
7/17/2003       problem with the interrupt 0x13 extensions detection code.
```


ALSO  There was a note about the upcoming version.
```
Future changes planned for Version 1.3.2:
-----------------------------------------------------------------------------
TO-DO           Change the int 0x13 extension determination code.

                Add the partition id bytes.

```
 