### PR TITLE
fix critical bugs: disk size detection and wrong partition table loading

### DIFF
--- a/SOURCE/FDISK/MAIN.C
+++ b/SOURCE/FDISK/MAIN.C
@@ -76,6 +76,7 @@ unsigned long Convert_Cyl_To_MB( unsigned long num_cyl,
                                  unsigned long total_heads,
                                  unsigned long total_sect )
 {
+   /* seems to round at 0.5 MB ( sect_per_meg / 2 ) */
    unsigned long sect_per_meg = 1048576ul / 512;
    return (
       ( ( ( num_cyl * total_heads ) * total_sect ) + ( sect_per_meg / 2 ) ) /

--- a/SOURCE/FDISK/PDISKIO.C
+++ b/SOURCE/FDISK/PDISKIO.C
@@ -671,7 +671,7 @@ void Get_Partition_Information( void )
       for ( partnum = 0; partnum < 4; partnum++ ) {
          strcpy( pDrive->pri_part[partnum].vol_label, "           " );
 
-         /* Check for and get the volume label on a FAT12/FAT16 partition. */
+         /* Check for and get the volume label on a FAT partition. */
          if ( IsRecognizedFatPartition(
                  pDrive->pri_part[partnum].num_type ) ) {
             if ( pDrive->pri_part[partnum].num_type == 11 ||
@@ -986,7 +986,7 @@ int Read_Partition_Tables( void )
                   Extract_Cylinder_From_LBA_Value(
                      /* */
                      ( pDrive->pri_part[index].rel_sect +
-                       pDrive->pri_part[index].num_sect ),
+                       pDrive->pri_part[index].num_sect - 1 ),
                      0 //!!,pDrive->pri_part[index].end_head
                      ,
                      1 //!!,pDrive->pri_part[index].end_sect
@@ -1123,7 +1123,7 @@ int Read_Partition_Tables( void )
                            Extract_Cylinder_From_LBA_Value(
                               ( pDrive->log_drive[index].rel_sect +
                                 pDrive->ptr_ext_part->rel_sect +
-                                pDrive->log_drive[index].num_sect ),
+                                pDrive->log_drive[index].num_sect - 1 ),
                               0 //!!,pDrive->log_drive[index].end_head
                               ,
                               1 //!!,pDrive->log_drive[index].end_sect
@@ -1136,7 +1136,7 @@ int Read_Partition_Tables( void )
                               ( pDrive->log_drive[index].rel_sect +
                                 pDrive->ptr_ext_part->rel_sect +
                                 pDrive->log_drive[index].num_sect +
-                                pDrive->next_ext[index - 1].rel_sect ),
+                                pDrive->next_ext[index - 1].rel_sect - 1 ),
                               0 //!!,pDrive->log_drive[index].end_head
                               ,
                               1 //!!,pDrive->log_drive[index].end_sect
@@ -1206,7 +1206,7 @@ int Read_Partition_Tables( void )
                            Extract_Cylinder_From_LBA_Value(
                               ( pDrive->next_ext[index].rel_sect +
                                 pDrive->ptr_ext_part->rel_sect +
-                                pDrive->next_ext[index].num_sect ),
+                                pDrive->next_ext[index].num_sect - 1 ),
                               pDrive->next_ext[index].end_head,
                               pDrive->next_ext[index].end_sect,
                               pDrive->total_head, pDrive->total_sect );

--- a/SOURCE/FDISK/PDISKIO.C
+++ b/SOURCE/FDISK/PDISKIO.C
@@ -110,7 +110,6 @@ void Check_For_INT13_Extensions( void )
    int carry;
    int drive_number = 0x80;
 
-   //-  unsigned int ah_register;
    unsigned char ah_register = 0;
    unsigned int bx_register = 0;
    unsigned int cx_register = 0;
@@ -125,7 +124,6 @@ void Check_For_INT13_Extensions( void )
 #endif
 
    do {
-      //    carry=99;
       carry = 0;
 
       asm {
@@ -137,17 +135,9 @@ void Check_For_INT13_Extensions( void )
       mov BYTE PTR ah_register,ah
       mov WORD PTR bx_register,bx
       mov WORD PTR cx_register,cx
-
-            //      jnc carry_flag_not_set    /* Jump if the carry flag is clear  */
-            //      }                         /* If the carry flag is clear, then */
-            //				/* the extensions exist.            */
-            //    carry=1;
-            //    part_table[(drive_number-128)].ext_int_13=FALSE;
       adc WORD PTR carry,0 /* Set carry if CF=1 */
       }
 
-      //    carry_flag_not_set:
-      //    if( (carry==99) && (bx_register==0xaa55) )
       part_table[( drive_number - 128 )].ext_int_13 = FALSE;
 
       if ( ( !carry ) && ( bx_register == 0xaa55 ) ) {
@@ -328,8 +318,7 @@ int Determine_Drive_Letters( void )
                     brief_partition_table[index][sub_index] ) ) {
                drive_lettering_buffer[index][sub_index] = current_letter;
                current_letter++;
-               sub_index =
-                  5; /* Set sub_index = 5 to break out of loop early. */
+               break;
             }
 
             sub_index++;
@@ -376,12 +365,12 @@ int Determine_Drive_Letters( void )
    } while ( index < 8 );
 
    /* Find the Non-DOS Logical Drives in the Extended Partition Table */
-   non_dos_partition_counter = '1';
    index = 0;
    do {
       Partition_Table *pDrive = &part_table[index];
 
       pDrive->num_of_non_dos_log_drives = 0;
+      non_dos_partition_counter = '1';
       sub_index = 4;
 
       do {
@@ -404,7 +393,6 @@ int Determine_Drive_Letters( void )
          sub_index++;
       } while ( sub_index < 27 );
 
-      non_dos_partition_counter = '1';
       index++;
    } while ( index < 8 );
 

--- a/SOURCE/FDISK/PDISKIO.C
+++ b/SOURCE/FDISK/PDISKIO.C
@@ -630,7 +630,7 @@ int Get_Hard_Drive_Parameters( int physical_drive )
 
    /* Check for an extra cylinder */
    if ( flags.check_for_extra_cylinder == TRUE ) {
-      if ( 0 == Read_Physical_Sectors( physical_drive, ( total_cylinders ),
+      if ( 0 == Read_Physical_Sectors( physical_drive, total_cylinders + 1,
                                        total_heads, total_sectors, 1 ) ) {
          total_cylinders++;
       }

--- a/SOURCE/FDISK/PDISKIO.H
+++ b/SOURCE/FDISK/PDISKIO.H
@@ -86,6 +86,9 @@ struct Partition {
 typedef struct part_table_structure {
 
    /* Hard disk Geometry */
+   /* total_cyl and total_head are actually not the total but the highest
+      values as returned by BIOS (zero based!). One has to +1 to get the
+      total count!!! */
    unsigned long total_cyl;
    unsigned long total_head;
    unsigned long total_sect;


### PR DESCRIPTION
These fixes should be double checked before released into the wild. There may be more errors of this form, but I have not tested all possible cases yet.

These errors occur even if FDISK is used as the only partitioning tool and therefore should be considered critical.

Please see the commit messages for a more detailed explanation of the errors.