### PR TITLE
Fix #21 and implement /IFEMPTY

### DIFF
--- a/DOC/FDISK/CHANGES.md
+++ b/DOC/FDISK/CHANGES.md
@@ -2,6 +2,18 @@ Free FDISK Change Log
 =====================
 
 
+Version 1.3.6 (unreleased)
+--------------------------
+Bugfixes:
+ - CRITICAL: Prevent user from specifying multiple disks via command line
+     leading to commands operating on the wrong disk.
+ - LOW: Work around AT BIOS bug. It is LOW because it actually does not get
+     triggered by the current version.
+
+Other changes:
+ - Implement /IFEMPTY command for use by the FreeDOS installers.
+
+
 Version 1.3.5 (2023-03-19)
 --------------------------
 Bugfixes:

--- a/SOURCE/FDISK/CMD.C
+++ b/SOURCE/FDISK/CMD.C
@@ -594,7 +594,7 @@ int Get_Options( char *argv[], int argc )
           
          }
          else if ( flags.drive_number != ( argptr[0] - '0' ) + 127 ) {
-            printf( "more than one drive specified; terminated\n", argptr );
+            printf( "more than one drive specified; terminated\n" );
             exit( 9 );       
          }
          number_of_options--;

--- a/SOURCE/FDISK/CMD.C
+++ b/SOURCE/FDISK/CMD.C
@@ -606,7 +606,6 @@ int Get_Options( char *argv[], int argc )
    char *argptr;
    int i;
    int number_of_options = 0;
-
    flags.drive_number = 0x80;
 
    argc--, argv++; /* absorb program name */
@@ -633,8 +632,15 @@ int Get_Options( char *argv[], int argc )
             exit( 9 );
          }
 
-         flags.drive_number = ( argptr[0] - '0' ) + 127;
-         flags.using_default_drive_number = FALSE;
+         if ( flags.using_default_drive_number ) {
+            flags.drive_number = ( argptr[0] - '0' ) + 127;
+            flags.using_default_drive_number = FALSE;
+          
+         }
+         else if ( flags.drive_number != ( argptr[0] - '0' ) + 127 ) {
+            printf( "more than one drive specified; terminated\n", argptr );
+            exit( 9 );       
+         }
          number_of_options--;
          continue;
       }

--- a/SOURCE/FDISK/CMD.C
+++ b/SOURCE/FDISK/CMD.C
@@ -24,20 +24,6 @@ $set 2
 20 no partition deleted
 */
 
-/*
-/////////////////////////////////////////////////////////////////////////////
-//  DEFINES
-/////////////////////////////////////////////////////////////////////////////
-*/
-
-#define CMD
-
-/*
-/////////////////////////////////////////////////////////////////////////////
-//  INCLUDES
-/////////////////////////////////////////////////////////////////////////////
-*/
-
 #include <conio.h>
 #include <ctype.h>
 #include <stdio.h>
@@ -53,34 +39,6 @@ $set 2
 #include "userint1.h"
 #include "userint2.h"
 
-/*
-/////////////////////////////////////////////////////////////////////////////
-//  PROTOTYPES
-/////////////////////////////////////////////////////////////////////////////
-*/
-
-int Get_Options( char *arguments[], int number_of_arguments );
-
-void Command_Line_Clear_Flag( void );
-void Command_Line_Create_Extended_Partition( void );
-void Command_Line_Create_Logical_DOS_Drive( void );
-void Command_Line_Create_Primary_Partition( void );
-void Command_Line_Delete( void );
-void Command_Line_Info( void );
-void Command_Line_Modify( void );
-void Command_Line_Move( void );
-void Command_Line_Set_Flag( void );
-void Command_Line_Status( void );
-void Command_Line_Swap( void );
-void Command_Line_Test_Flag( void );
-void Command_Line_X( void );
-void Shift_Command_Line_Options( int number_of_places );
-
-/*
-/////////////////////////////////////////////////////////////////////////////
-//  FUNCTIONS
-/////////////////////////////////////////////////////////////////////////////
-*/
 
 /* /CLEARFLAG command line option */
 void Command_Line_Clear_Flag( void )
@@ -154,8 +112,6 @@ void Command_Line_Create_Extended_Partition( void )
 
    maximum_possible_percentage = Convert_To_Percentage(
       maximum_partition_size_in_MB, pDrive->disk_size_mb );
-
-   //   ,pDrive->ext_size_mb);
 
    if ( arg[0].extra_value == 100 ) {
       /* Set limit on percentage. */

--- a/SOURCE/FDISK/COMPAT.C
+++ b/SOURCE/FDISK/COMPAT.C
@@ -99,7 +99,9 @@ get_pos:
    mov bh, byte ptr _textattr
    xor cx, cx
    mov dx, 184Fh
+   push bp
    int 10h
+   pop bp
    mov dx, 1800h
 
 move_cursor:

--- a/SOURCE/FDISK/HELPSCR.C
+++ b/SOURCE/FDISK/HELPSCR.C
@@ -44,28 +44,28 @@ void Display_Help_Screen( void )
 
    printf( "%-20s                   %40s\n", name, version );
    printf(
-      "Syntax: FDISK [argument]...\n"
+      "Syntax: FDISK [<drive#>] [commands]...\n"
       "  no argument       Runs in interactive mode\n"
-      "  /INFO [<drive#>]  Displays partition information of <drive#>\n"
+      "  /INFO             Displays partition information of <drive#>\n"
       "  /REBOOT           Reboots the Computer\n"
       "\n"
       "Commands to create and delete partitions:\n"
       "    <size> is a number for megabytes or MAX for maximum size\n"
       "           or <number>,100 for <number> to be in percent\n"
       "    <type#> is a numeric partition type or FAT-12/16/32 if /SPEC not given\n\n"
-      "  /PRI:<size> [/SPEC:<type#>] [drive#]     Creates a primary partition\n"
-      "  /EXT:<size> [drive#]                     Creates an extended DOS partition\n"
-      "  /LOG:<size> [/SPEC:<type#>] [drive#]     Creates a logical drive\n"
+      "  /PRI:<size> [/SPEC:<type#>]              Creates a primary partition\n"
+      "  /EXT:<size>                              Creates an extended DOS partition\n"
+      "  /LOG:<size> [/SPEC:<type#>]              Creates a logical drive\n"
       "  /PRIO,/EXTO,/LOGO                        same as above, but avoids FAT32\n"
-      "  /AUTO [drive#]                           Automatically partitions the disk\n"
+      "  /AUTO                                    Automatically partitions the disk\n"
       "\n"
       "  /DELETE {/PRI[:#] | /EXT | /LOG:<part#>  Deletes a partition\n"
-      "           | /NUM:<part#>} [drive#]        ...logical drives start at /NUM=5\n"
-      "  /DELETEALL [drive#]                      Deletes all partitions from <drive#>\n"
+      "           | /NUM:<part#>}                 ...logical drives start at /NUM=5\n"
+      "  /DELETEALL                               Deletes all partitions from <drive#>\n"
       "\n"
       "Setting active partitions:\n"
-      "  /ACTIVATE:<partition#> [drive#]          Sets <partition#> active\n"
-      "  /DEACTIVATE [drive#]                     Deactivates all partitions\n" );
+      "  /ACTIVATE:<partition#>                   Sets <partition#> active\n"
+      "  /DEACTIVATE                              Deactivates all partitions\n" );
    if ( flags.do_not_pause_help_information == FALSE ) {
       //printf("\n\n");
       Pause();
@@ -76,27 +76,27 @@ void Display_Help_Screen( void )
 
    printf(
       "MBR (Master Boot Record) management:\n"
-      "  /CLEARMBR [drive#]       Deletes all partitions and boot code\n"
-      "  /LOADMBR  [drive#]       Loads part. table and code from \"boot.mbr\" into MBR\n"
-      "  /SAVEMBR  [drive#]       Saves partition table and code into file \"boot.mbr\"\n"
+      "  /CLEARMBR                Deletes all partitions and boot code\n"
+      "  /LOADMBR                 Loads part. table and code from \"boot.mbr\" into MBR\n"
+      "  /SAVEMBR                 Saves partition table and code into file \"boot.mbr\"\n"
       "\n"
       "MBR code modifications leaving partitions intact:\n"
-      "  /IPL      [drive#]       Installs the standard boot code into MBR <drive#>\n"
+      "  /IPL                     Installs the standard boot code into MBR <drive#>\n"
       "                           ...same as /MBR and /CMBR for compatibility\n"
-      "  /SMARTIPL [drive#]       Installs DriveSmart IPL into MBR <drive#>\n"
+      "  /SMARTIPL                Installs DriveSmart IPL into MBR <drive#>\n"
       /*      "  /CLEARIPL [drive#]       Zeros 440 code bytes of MBR\n"*/
-      "  /LOADIPL  [drive#]       Writes 440 code bytes from \"boot.mbr\" into MBR\n"
+      "  /LOADIPL                 Writes 440 code bytes from \"boot.mbr\" into MBR\n"
       "\n"
       "Advanced partition table modification:\n"
-      "  /MODIFY:<part#>,<type#> [drive#]           Changes partition type to <type#>\n"
+      "  /MODIFY:<part#>,<type#>                    Changes partition type to <type#>\n"
       "                                             ...logical drives start at \"5\"\n"
-      "  /MOVE:<srcpart#>,<destpart#> [drive#]      Moves primary partitions\n"
-      "  /SWAP:<1stpart#>,<2ndpart#>  [drive#]      Swaps primary partitions\n"
+      "  /MOVE:<srcpart#>,<destpart#>               Moves primary partitions\n"
+      "  /SWAP:<1stpart#>,<2ndpart#>                Swaps primary partitions\n"
       "\n"
       "For handling flags on a hard disk:\n"
-      "  /CLEARFLAG[{:<flag#>} | /ALL}] [drive#]    Resets <flag#> or all on <drive#>\n"
-      "  /SETFLAG:<flag#>[,<value>] [drive#]        Sets <flag#> to 1 or <value>\n"
-      "  /TESTFLAG:<flag#>[,<value>] [drive#]       Tests <flag#> for 1 or <value>\n" );
+      "  /CLEARFLAG[{:<flag#>} | /ALL}]             Resets <flag#> or all on <drive#>\n"
+      "  /SETFLAG:<flag#>[,<value>]                 Sets <flag#> to 1 or <value>\n"
+      "  /TESTFLAG:<flag#>[,<value>]                Tests <flag#> for 1 or <value>\n" );
    if ( flags.do_not_pause_help_information == FALSE ) {
       printf( "\n" );
       Pause();

--- a/SOURCE/FDISK/MAIN.C
+++ b/SOURCE/FDISK/MAIN.C
@@ -824,7 +824,7 @@ void main( int argc, char *argv[] )
          }
 
          if ( 0 == strcmp( arg[0].choice, "IFEMPTY" ) ) {
-            /* only execute th following commands if part tbl is empty */
+            /* only execute the following commands if part tbl is empty */
             if ( !Is_Pri_Tbl_Empty() ) {
                exit( 0 );
             }

--- a/SOURCE/FDISK/MAIN.C
+++ b/SOURCE/FDISK/MAIN.C
@@ -823,6 +823,15 @@ void main( int argc, char *argv[] )
             }
          }
 
+         if ( 0 == strcmp( arg[0].choice, "IFEMPTY" ) ) {
+            /* only execute th following commands if part tbl is empty */
+            if ( !Is_Pri_Tbl_Empty() ) {
+               exit( 0 );
+            }
+            Shift_Command_Line_Options( 1 );
+            command_ok = TRUE;
+         }
+
          if ( 0 == strcmp( arg[0].choice, "INFO" ) ) {
             flags.use_iui = FALSE;
             Command_Line_Info();

--- a/SOURCE/FDISK/MAIN.H
+++ b/SOURCE/FDISK/MAIN.H
@@ -3,7 +3,7 @@
 #define FD_NAME "FreeDOS FDISK"
 #endif
 
-#define VERSION  "1.3.5"
+#define VERSION  "1.3.6"
 #define COPYLEFT "1998 - 2023"
 
 #ifndef FD_NAME

--- a/SOURCE/FDISK/PCOMPUTE.C
+++ b/SOURCE/FDISK/PCOMPUTE.C
@@ -3,7 +3,6 @@
 #define MAXFAT16NORM  2047
 #define MAXFAT16LARGE 4095
 
-#include <dos.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/SOURCE/FDISK/PDISKIO.C
+++ b/SOURCE/FDISK/PDISKIO.C
@@ -120,6 +120,20 @@ int Is_Supp_Ext_Part( int num_type )
               flags.version == W98 ) );
 }
 
+int Is_Pri_Tbl_Empty( void )
+{
+   int index;
+   Partition_Table *pDrive = &part_table[flags.drive_number - 0x80];
+
+   for ( index = 0; index < 4; index++ ) {
+      if ( pDrive->pri_part[index].num_type != 0 ) {
+         return 0;
+      }
+   }
+
+   return 1;
+}
+
 /* Clear the Boot Sector of a partition */
 void Clear_Boot_Sector( int drive, unsigned long cylinder, unsigned long head,
                         unsigned long sector )

--- a/SOURCE/FDISK/PDISKIO.H
+++ b/SOURCE/FDISK/PDISKIO.H
@@ -120,6 +120,7 @@ int IsRecognizedFatPartition( unsigned );
 int Is_Dos_Part( int part_type );
 int Is_Ext_Part( int num_type );
 int Is_Supp_Ext_Part( int num_tyoe );
+int Is_Pri_Tbl_Empty( void );
 
 /* sets all partition values to zero */
 void Clear_Partition( Partition *p );

--- a/SOURCE/FDISK/USERINT2.C
+++ b/SOURCE/FDISK/USERINT2.C
@@ -934,15 +934,20 @@ void Display_CL_Partition_Table( void )
 
    Determine_Drive_Letters();
 
-   printf( "\n\nCurrent fixed disk drive: %1d",
+   printf( "\nCurrent fixed disk drive: %1d",
            ( flags.drive_number - 127 ) );
 
    printf( "   %lu sectors, geometry %lu/%03lu/%02lu", pDrive->disk_size_sect,
            pDrive->total_cyl + 1, pDrive->total_head + 1,
            pDrive->total_sect );
 
-   printf( "\n\nPartition   Status   Mbytes   Description      Usage" );
-   printf( "    Start CHS       End CHS\n" );
+   if ( !Is_Pri_Tbl_Empty() ) {
+      printf( "\n\nPartition   Status   Mbytes   Description      Usage" );
+      printf( "    Start CHS       End CHS\n" );
+   }
+   else {
+      printf("\n\nNo partitions defined.\n");
+   }
 
    index = 0;
    do {
@@ -1472,7 +1477,7 @@ void Dump_Partition_Information( void )
       flags.drive_number = index + 128;
       Display_CL_Partition_Table();
       index++;
-   } while ( index <= 7 );
+   } while ( index + 128 <= flags.maximum_drive_number );
 }
 
 /* List the Partition Types */

--- a/SOURCE/FDISK/USERINT2.C
+++ b/SOURCE/FDISK/USERINT2.C
@@ -1068,6 +1068,7 @@ void Display_CL_Partition_Table( void )
          "\nLargest continious free space in extended partition = %lu MBytes\n",
          Max_Log_Free_Space_In_MB() );
    }
+   printf("\n");
 }
 
 /* Display Extended Partition Information Sub Screen */


### PR DESCRIPTION
Merge request for 4 eyes principle :-)

- 7e3ecf0ada33bc854833814b43829662730499f2 fixes #21 
- b0eb958cb89baefe6d16b4d4c3e03286457e9059 fixes a BUG that gets triggered by AT BIOS invalidating BP 
- b78ce5c9395f3a23ab2ce796a01ff7dd37115c81 implements `/IFEMPTY` to only execute the following commands if no partitions exist (for FreeDOS installer)