### PR TITLE
forgotten fclose() and upx only distribuable binary

### DIFF
--- a/SOURCE/FDISK/MAKEFILE.WAT
+++ b/SOURCE/FDISK/MAKEFILE.WAT
@@ -1,7 +1,7 @@
 # This makefile is for Free FDISK and Open Watcom.
 #
 # Created by Bernd Boeckmann
-#   for verison 1.3.4 and Open Watcom 1.9.
+#   for version 1.3.4 and Open Watcom 1.9.
 
 CC       = wcc
 CFLAGS   = -q -0 -bt=dos -w4
@@ -45,8 +45,8 @@ dist : ..\..\fdisk.zip
 
 fdisk.exe : $(objs) fdisk.lnk
 	$(LD) $(LDFLAGS) @fdisk
-	-$(PACKER) $(PACKERFLAGS) $^@
 	-copy /y fdisk.exe ..\..\bin\fdisk.exe
+	-$(PACKER) $(PACKERFLAGS) ..\..\bin\fdisk.exe
 
 fdisk.lnk : $(objs)
 	@echo NAME $^& >$^@
@@ -62,7 +62,7 @@ fdisk.lnk : $(objs)
 	cd ..\..
   zip -r fdisk.zip appinfo bin doc help source\fdisk\*.[ch] &
   source\fdisk\*.asm source\fdisk\makefile.* license readme.md
-  cd source\fdisk  
+  cd source\fdisk
 
 test.exe : test.c compat.c
   $(CL) $(CLFLAGS) test.c compat.c

--- a/SOURCE/FDISK/USERINT1.C
+++ b/SOURCE/FDISK/USERINT1.C
@@ -452,6 +452,7 @@ void Interactive_User_Interface( void )
          /* PATH in the environment for the boot.mbr file.                  */
          file_pointer = fopen( home_path, "rb" );
 
+         /* if .\boot.mbr not found, then look for it in %PATH% */
          if ( !file_pointer ) {
             file_pointer = fopen( searchpath( "boot.mbr" ), "rb" );
          }
@@ -462,6 +463,7 @@ void Interactive_User_Interface( void )
                "\nUnable to find the \"boot.mbr\" file...MBR has not been loaded.\n" );
          }
          else {
+            fclose(file_pointer);
             Load_MBR( 0 );
             Color_Print_At( 4, 22,
                             "MBR has been written using \"boot.mbr\"" );


### PR DESCRIPTION
Hello, I've glanced at the FDISK code and I respectfully suggest these two changes

The missing fclose() is probably self-explanatory. The upx change is to delay upxing the binary until the distribuable-package-generation. The rationale is that it is useful to study the executable before it gets upxed, for example to know its exact in-memory size and disassembly it.