### PR TITLE
build fails on MSDOS 6.0 because of COPY/Y

### DIFF
--- a/SOURCE/FDISK/MAKEFILE.WAT
+++ b/SOURCE/FDISK/MAKEFILE.WAT
@@ -45,7 +45,8 @@ dist : ..\..\fdisk.zip
 
 fdisk.exe : $(objs) fdisk.lnk
 	$(LD) $(LDFLAGS) @fdisk
-	-copy /y fdisk.exe ..\..\bin\fdisk.exe
+	-del ..\..\bin\fdisk.exe
+	-copy fdisk.exe ..\..\bin\fdisk.exe
 	-$(PACKER) $(PACKERFLAGS) ..\..\bin\fdisk.exe
 
 fdisk.lnk : $(objs)


### PR DESCRIPTION
COPY /Y is a modern invention, not present in MSDOS at least until 6.x (I stopped looking after 6.0). This proposition is about replacing the COPY/Y used in Makefile by a perhaps less elegant, but more universal DEL+COPY combo.